### PR TITLE
Fix: Add Missing Indexes

### DIFF
--- a/app/components/tasks/forms/createTask.tsx
+++ b/app/components/tasks/forms/createTask.tsx
@@ -188,7 +188,7 @@ export function TaskForm<Props extends PropsFullPage<Task>>({
       .map(({ eventsStorage }) => {
         return todos.map((todo) => {
           const event = eventsStorage
-            .find(({ todo_id }) => todo_id != null && todo_id === todo.id)
+            .find({ todo_id: todo.id })
             .then((found) => {
               const event = found.map<LocalValue<CalendarEvent>>((event) => ({
                 ...event,
@@ -234,7 +234,7 @@ export function TaskForm<Props extends PropsFullPage<Task>>({
       }
       for await (const listItem of changeList(initialTodoList)) {
         result.push(
-          listItem as [
+          listItem as unknown as [
             Todo["id"],
             {
               event: Option<LocalValue<CalendarEvent>>;

--- a/src/services/boards/boards.ts
+++ b/src/services/boards/boards.ts
@@ -159,6 +159,34 @@ export class BoardStorage
     const resultAsync = async () => this.boards.get(id);
     return resultAsync();
   }
+
+  find(searched: Partial<Board>): Promise<Board[]> {
+    return (async () => {
+      const keys = Object.keys(searched) as (keyof Board)[];
+      if (keys.length === 1 && keys[0] !== "id") {
+        const from = keys[0];
+        const valueFrom = searched[from];
+
+        if (valueFrom != null) {
+          const foundOnIndex = this.boards.allWithIndex(from, "id", valueFrom);
+          if (foundOnIndex.isSome()) {
+            const valuesFromIndex = [];
+            for (const id of foundOnIndex.unwrap()) {
+              const value = this.boards.get(id);
+              if (value.isSome()) valuesFromIndex.push(value.unwrap());
+            }
+
+            return valuesFromIndex;
+          }
+        }
+      }
+      const keysToLook = Object.keys(searched) as (keyof Board)[];
+      return this.filteredValues((searchee) => {
+        return !keysToLook.some((key) => searchee[key] !== searched[key]);
+      });
+    })();
+  }
+
   filteredValues(predicate: (value: Board) => boolean): Promise<Board[]> {
     const resultAsync = async () => this.boards.filterValues(predicate);
     return resultAsync();

--- a/src/services/calendar/calendar.ts
+++ b/src/services/calendar/calendar.ts
@@ -259,6 +259,33 @@ class CalendarStorage
     return resultAsync();
   }
 
+  find(searched: Partial<Calendar>): Promise<Calendar[]> {
+    return (async () => {
+      const keys = Object.keys(searched) as (keyof Calendar)[];
+      if (keys.length === 1 && keys[0] !== "id") {
+        const from = keys[0];
+        const valueFrom = searched[from];
+
+        if (valueFrom != null) {
+          const foundOnIndex = this.map.allWithIndex(from, "id", valueFrom);
+          if (foundOnIndex.isSome()) {
+            const valuesFromIndex = [];
+            for (const id of foundOnIndex.unwrap()) {
+              const value = this.map.get(id);
+              if (value.isSome()) valuesFromIndex.push(value.unwrap());
+            }
+
+            return valuesFromIndex;
+          }
+        }
+      }
+      const keysToLook = Object.keys(searched) as (keyof Calendar)[];
+      return this.filteredValues((searchee) => {
+        return !keysToLook.some((key) => searchee[key] !== searched[key]);
+      });
+    })();
+  }
+
   findDefault() {
     const calendars = this.map.values();
     for (const calendar of calendars) {

--- a/src/services/events/eventTemplates.ts
+++ b/src/services/events/eventTemplates.ts
@@ -151,6 +151,37 @@ export class EventTemplateStorage
     return resultAsync();
   }
 
+  find(searched: Partial<EventTemplate>): Promise<EventTemplate[]> {
+    return (async () => {
+      const keys = Object.keys(searched) as (keyof EventTemplate)[];
+      if (keys.length === 1 && keys[0] !== "id") {
+        const from = keys[0];
+        const valueFrom = searched[from];
+
+        if (valueFrom != null) {
+          const foundOnIndex = this.eventTemplates.allWithIndex(
+            from,
+            "id",
+            valueFrom,
+          );
+          if (foundOnIndex.isSome()) {
+            const valuesFromIndex = [];
+            for (const id of foundOnIndex.unwrap()) {
+              const value = this.eventTemplates.get(id);
+              if (value.isSome()) valuesFromIndex.push(value.unwrap());
+            }
+
+            return valuesFromIndex;
+          }
+        }
+      }
+      const keysToLook = Object.keys(searched) as (keyof EventTemplate)[];
+      return this.filteredValues((searchee) => {
+        return !keysToLook.some((key) => searchee[key] !== searched[key]);
+      });
+    })();
+  }
+
   all() {
     const resultAsync = async () => this.eventTemplates.values();
     return resultAsync();

--- a/src/services/events/events.ts
+++ b/src/services/events/events.ts
@@ -156,16 +156,55 @@ class EventStorage
     return resultAsync();
   }
 
-  find(predicate: (event: CalendarEvent) => boolean) {
-    for (const event of this.map.values()) {
-      if (predicate(event)) {
-        const resultAsync = async () => O.Some(event);
-        return resultAsync();
-      }
-    }
+  find(searched: Partial<CalendarEvent>): Promise<CalendarEvent[]> {
+    return (async () => {
+      const keys = Object.keys(searched) as (keyof CalendarEvent)[];
+      if (keys.length === 1 && keys[0] !== "id") {
+        const from = keys[0];
+        const valueFrom = searched[from];
 
-    const resultAsync = async () => O.None();
-    return resultAsync();
+        if (valueFrom != null) {
+          const foundOnIndex = this.map.allWithIndex(from, "id", valueFrom);
+          if (foundOnIndex.isSome()) {
+            const valuesFromIndex = [];
+            for (const id of foundOnIndex.unwrap()) {
+              const value = this.map.get(id);
+              if (value.isSome()) valuesFromIndex.push(value.unwrap());
+            }
+
+            return valuesFromIndex;
+          }
+        }
+      }
+      const keysToLook = Object.keys(searched) as (keyof CalendarEvent)[];
+      return this.filteredValues((searchee) => {
+        return !keysToLook.some((key) => {
+          const searchedValue = searched[key];
+          const searcheeValue = searchee[key];
+          if (searchedValue instanceof O.OptionClass) {
+            if (
+              searcheeValue instanceof O.OptionClass &&
+              searcheeValue.isSome() &&
+              searchedValue.isSome()
+            ) {
+              return searchedValue.unwrap() !== searcheeValue.unwrap();
+            }
+
+            if (
+              searcheeValue instanceof O.OptionClass &&
+              !searcheeValue.isSome() &&
+              !searchedValue.isSome()
+            ) {
+              return false;
+            }
+
+            return true;
+          }
+
+          return searchee[key] !== searched[key];
+        });
+      });
+    })();
   }
 
   filter(predicate: (event: CalendarEvent) => boolean) {

--- a/src/services/task/task.ts
+++ b/src/services/task/task.ts
@@ -170,6 +170,34 @@ export class TaskStorage
     const resultAsync = async () => this.map.get(id);
     return resultAsync();
   }
+
+  find(searched: Partial<Task>): Promise<Task[]> {
+    return (async () => {
+      const keys = Object.keys(searched) as (keyof Task)[];
+      if (keys.length === 1 && keys[0] !== "id") {
+        const from = keys[0];
+        const valueFrom = searched[from];
+
+        if (valueFrom != null) {
+          const foundOnIndex = this.map.allWithIndex(from, "id", valueFrom);
+          if (foundOnIndex.isSome()) {
+            const valuesFromIndex = [];
+            for (const id of foundOnIndex.unwrap()) {
+              const value = this.map.get(id);
+              if (value.isSome()) valuesFromIndex.push(value.unwrap());
+            }
+
+            return valuesFromIndex;
+          }
+        }
+      }
+      const keysToLook = Object.keys(searched) as (keyof Task)[];
+      return this.filteredValues((searchee) => {
+        return !keysToLook.some((key) => searchee[key] !== searched[key]);
+      });
+    })();
+  }
+
   filteredValues(predicate: (value: Task) => boolean): Promise<Task[]> {
     const resultAsync = async () => this.map.filterValues(predicate);
     return resultAsync();

--- a/src/services/todo/todo.ts
+++ b/src/services/todo/todo.ts
@@ -149,6 +149,33 @@ export class TodoStorage
     return resultAsync();
   }
 
+  find(searched: Partial<Todo>): Promise<Todo[]> {
+    return (async () => {
+      const keys = Object.keys(searched) as (keyof Todo)[];
+      if (keys.length === 1 && keys[0] !== "id") {
+        const from = keys[0];
+        const valueFrom = searched[from];
+
+        if (valueFrom != null) {
+          const foundOnIndex = this.map.allWithIndex(from, "id", valueFrom);
+          if (foundOnIndex.isSome()) {
+            const valuesFromIndex = [];
+            for (const id of foundOnIndex.unwrap()) {
+              const value = this.map.get(id);
+              if (value.isSome()) valuesFromIndex.push(value.unwrap());
+            }
+
+            return valuesFromIndex;
+          }
+        }
+      }
+      const keysToLook = Object.keys(searched) as (keyof Todo)[];
+      return this.filteredValues((searchee) => {
+        return !keysToLook.some((key) => searchee[key] !== searched[key]);
+      });
+    })();
+  }
+
   filteredValues(predicate: (value: Todo) => boolean): Promise<Todo[]> {
     const resultAsync = async () => this.map.filterValues(predicate);
     return resultAsync();

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -365,5 +365,6 @@ export interface StorageActions<K, V extends Record<string, any> & { id: K }> {
   removeAll(list: K[]): Promise<Array<[K, V]>>;
   findById(id: K): Promise<O.Option<V>>;
   filteredValues(predicate: (value: V) => boolean): Promise<V[]>;
+  find(value: Partial<V>): Promise<V[]>;
   all(): Promise<V[]>;
 }


### PR DESCRIPTION
## About

This closes #1 by adding indexing the `task_id` field of `CalendarEvent` as no other index is needed right now for the v0.2.0