### PR TITLE
Fix/Events Markdown

### DIFF
--- a/components/shared/event-forms/eventForm.tsx
+++ b/components/shared/event-forms/eventForm.tsx
@@ -90,7 +90,9 @@ export const EventForm = <T extends Omit<CalendarEvent, "id"> | CalendarEvent>({
       setForm(form);
     };
 
-  const [markdownPreview, setMarkdownPreview] = useState(false);
+  const [markdownPreview, setMarkdownPreview] = useState(
+    form.description.length !== 0,
+  );
   return (
     <PopupForm
       onSubmit={() => {


### PR DESCRIPTION
## About

Fix the Edit Events form, which didn't show the markdown on startup for events with a description.