### PR TITLE
Feat/Calendar header

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,6 +31,7 @@ import { useShortcut } from "@/hooks/useShortcut";
 import { ShortcutBuilder } from "@/utils/shortcuts";
 import { SelectedDateContext } from "@/components/calendar-navbar/selectedDateContext";
 import { FormHandler } from "@/components/form-handler/formHandler";
+import { CalendarHeader } from "@/components/calendar-header-view/calendarHeader";
 
 const FlexContent = ({ children }: { children: any }) => {
   return <div className="flex relative overflow-hidden h-full">{children}</div>;
@@ -143,7 +144,8 @@ const CalendarContent = ({ startDate }: { startDate: Date }) => {
                 viewableCalendarsState={viewableCalendarsState}
                 className="p-1 max-w-min"
               />
-              <div className="ml-1 w-full max-h-[100%] bg-white relative">
+              <div className="ml-1 w-full max-h-[100%] bg-white relative flex flex-col">
+                <CalendarHeader />
                 {calendarMode
                   .map((mode) =>
                     mode === "normal" ? (

--- a/components/calendar-header-view/calendarHeader.tsx
+++ b/components/calendar-header-view/calendarHeader.tsx
@@ -1,0 +1,57 @@
+import { ChevronLeft, ChevronRight, Home } from "lucide-react";
+import { useContext, useEffect, useMemo, useState } from "react";
+import { SelectedDateContext } from "../calendar-navbar/selectedDateContext";
+import {
+  lastWeekMidnight,
+  nextWeekMidnight,
+  sundayInTheWeek,
+} from "@/utils/date";
+import { twMerge } from "tailwind-merge";
+
+export const CalendarHeader = () => {
+  const [date, setDate] = useContext(SelectedDateContext);
+
+  const [dateNow, setDateNow] = useState(Date.now());
+
+  useEffect(() => {
+    setTimeout(() => setDateNow(() => Date.now()), 60 * 1000);
+  }, [dateNow]);
+
+  const todayButtonHidden = useMemo(() => {
+    const timeDiffBetweenNowAndSelected = dateNow - date.getTime();
+    return timeDiffBetweenNowAndSelected < 7 * 24 * 60 * 60 * 1000 &&
+      timeDiffBetweenNowAndSelected > 0
+      ? "invisible"
+      : "visible";
+  }, [dateNow, date]);
+
+  return (
+    <div className="ml-[4px] mr-[16px] py-[4px] border rounded-b-md drop-shadow-md text-gray-600 inline-flex align-center px-[4px] gap-2">
+      <button
+        className="inline-flex justify-center align-center w-6 h-6 text-primary-500 hover:bg-gray-100 rounded-md"
+        onClick={() => {
+          setDate((date) => lastWeekMidnight(date));
+        }}
+      >
+        <ChevronLeft />
+      </button>
+      <button
+        className="inline-flex justify-center align-center w-6 h-6 text-primary-500 hover:bg-gray-100 rounded-md"
+        onClick={() => {
+          setDate((date) => nextWeekMidnight(date));
+        }}
+      >
+        <ChevronRight />
+      </button>
+      <button
+        className={twMerge(
+          "inline-flex justify-center align-center w-6 h-6 text-primary-500 hover:bg-gray-100 rounded-md ",
+          todayButtonHidden,
+        )}
+        onClick={() => setDate(() => sundayInTheWeek(new Date(dateNow)))}
+      >
+        <Home />
+      </button>
+    </div>
+  );
+};

--- a/components/calendar-header-view/calendarHeader.tsx
+++ b/components/calendar-header-view/calendarHeader.tsx
@@ -1,5 +1,18 @@
-import { ChevronLeft, ChevronRight, Home } from "lucide-react";
-import { useContext, useEffect, useMemo, useState } from "react";
+import {
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronUp,
+  Home,
+} from "lucide-react";
+import {
+  ComponentPropsWithoutRef,
+  PropsWithChildren,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { SelectedDateContext } from "../calendar-navbar/selectedDateContext";
 import {
   lastWeekMidnight,
@@ -25,33 +38,74 @@ export const CalendarHeader = () => {
       : "visible";
   }, [dateNow, date]);
 
+  const [collapseHeader, setDisplay] = useState(true);
+
+  const collapseContent = useMemo(
+    () => (collapseHeader ? "hidden opacity-0" : "opacity-100"),
+    [collapseHeader],
+  );
+  const CollapseIcon = useMemo(
+    () => (collapseHeader ? ChevronDown : ChevronUp),
+    [collapseHeader],
+  );
+  const paddingChange = useMemo(
+    () => (collapseHeader ? "py-0 -mb-[4px]" : ""),
+    [collapseHeader],
+  );
+
   return (
-    <div className="ml-[4px] mr-[16px] py-[4px] border rounded-b-md drop-shadow-md text-gray-600 inline-flex align-center px-[4px] gap-2">
-      <button
-        className="inline-flex justify-center align-center w-6 h-6 text-primary-500 hover:bg-gray-100 rounded-md"
+    <div
+      className={twMerge(
+        "relative ml-[4px] mr-[16px] py-[4px] border rounded-b-md drop-shadow-md min-h-2 text-gray-600 inline-flex align-center px-[4px] gap-2 transition-all ease-out",
+        paddingChange,
+      )}
+    >
+      <IconButton
+        className={"w-auto h-auto self-center"}
+        onClick={() => setDisplay((hide) => !hide)}
+      >
+        <CollapseIcon size={16} />
+      </IconButton>
+      <IconButton
+        className={twMerge("ml-auto", todayButtonHidden, collapseContent)}
+        onClick={() => setDate(() => sundayInTheWeek(new Date(dateNow)))}
+      >
+        <Home />
+      </IconButton>
+      <IconButton
+        className={twMerge(collapseContent)}
         onClick={() => {
           setDate((date) => lastWeekMidnight(date));
         }}
       >
         <ChevronLeft />
-      </button>
-      <button
-        className="inline-flex justify-center align-center w-6 h-6 text-primary-500 hover:bg-gray-100 rounded-md"
+      </IconButton>
+      <IconButton
+        className={twMerge(collapseContent)}
         onClick={() => {
           setDate((date) => nextWeekMidnight(date));
         }}
       >
         <ChevronRight />
-      </button>
-      <button
-        className={twMerge(
-          "inline-flex justify-center align-center w-6 h-6 text-primary-500 hover:bg-gray-100 rounded-md ",
-          todayButtonHidden,
-        )}
-        onClick={() => setDate(() => sundayInTheWeek(new Date(dateNow)))}
-      >
-        <Home />
-      </button>
+      </IconButton>
     </div>
+  );
+};
+
+const IconButton = ({
+  className,
+  children,
+  ...props
+}: PropsWithChildren<ComponentPropsWithoutRef<"button">>) => {
+  return (
+    <button
+      className={twMerge(
+        "inline-flex justify-center align-center w-6 h-6 text-primary-500 hover:bg-gray-100 rounded-md",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
   );
 };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -3,5 +3,34 @@ function getHTMLDateTime(date: Date) {
   return localdt.toISOString().slice(0, -1);
 }
 
-export { getHTMLDateTime };
+export const getMidnightDate = (date: Date) => {
+  const dateAtMidnightInMilliseconds = new Date(date).setHours(0, 0, 0, 0);
 
+  return new Date(dateAtMidnightInMilliseconds);
+};
+
+export const lastWeekMidnight = (date: Date) => {
+  const lastWeek = new Date(date.getTime() - 7 * 24 * 60 * 60 * 1000 + 1);
+  const lastWeekMidnight = getMidnightDate(lastWeek);
+
+  return lastWeekMidnight;
+};
+
+export const nextWeekMidnight = (date: Date) => {
+  const nextWeek = new Date(date.getTime() + 7 * 24 * 60 * 60 * 1000 + 1);
+  const nextWeekMidnight = getMidnightDate(nextWeek);
+
+  return nextWeekMidnight;
+};
+
+export const sundayInTheWeek = (date: Date) => {
+  const sundayDateInMiliseconds = new Date(date).setDate(
+    date.getDate() - date.getDay(),
+  );
+
+  const sundayMidnight = getMidnightDate(new Date(sundayDateInMiliseconds));
+
+  return sundayMidnight;
+};
+
+export { getHTMLDateTime };


### PR DESCRIPTION
## About

Add a Header right above the calendar view, with a simple navigation bar, enabling the user to walk through the weeks without using the mini calendar.